### PR TITLE
fix: move revel_names.json to root data/ dir (correct Railway path)

### DIFF
--- a/data/revel_names.json
+++ b/data/revel_names.json
@@ -1,0 +1,17282 @@
+{
+  "Aries|Aries|Aries": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Aries|Aries|Taurus": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Aries|Aries|Gemini": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Aries|Aries|Cancer": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Aries|Aries|Leo": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Aries|Aries|Virgo": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Aries|Aries|Libra": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Aries|Aries|Scorpio": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Aries|Sagittarius": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Aries|Capricorn": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Aries|Aquarius": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Aries|Pisces": {
+    "revelName": "Combustible Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Aries|Taurus|Aries": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Aries|Taurus|Taurus": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Aries|Taurus|Gemini": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Aries|Taurus|Cancer": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Aries|Taurus|Leo": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Aries|Taurus|Virgo": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Aries|Taurus|Libra": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Aries|Taurus|Scorpio": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Taurus|Capricorn": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Taurus|Aquarius": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Taurus|Pisces": {
+    "revelName": "Slow Burn Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Aries|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Aries|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Aries|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Aries|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Aries|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Aries|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Aries|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Aries|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Aries|Cancer|Aries": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Aries|Cancer|Taurus": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Aries|Cancer|Gemini": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Aries|Cancer|Cancer": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Aries|Cancer|Leo": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Aries|Cancer|Virgo": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Aries|Cancer|Libra": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Aries|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Cancer|Pisces": {
+    "revelName": "Deeply Felt Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Aries|Leo|Aries": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Aries|Leo|Taurus": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Aries|Leo|Gemini": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Aries|Leo|Cancer": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Aries|Leo|Leo": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Aries|Leo|Virgo": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Aries|Leo|Libra": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Aries|Leo|Scorpio": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Leo|Sagittarius": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Leo|Capricorn": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Leo|Aquarius": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Leo|Pisces": {
+    "revelName": "Golden Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Aries|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Aries|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Aries|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Aries|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Aries|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Aries|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Aries|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Aries|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Aries|Libra|Aries": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Aries|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Aries|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Aries|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Aries|Libra|Leo": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Aries|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Aries|Libra|Libra": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Aries|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Aries|Scorpio|Aries": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Aries|Scorpio|Taurus": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Aries|Scorpio|Gemini": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Aries|Scorpio|Cancer": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Aries|Scorpio|Leo": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Aries|Scorpio|Virgo": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Aries|Scorpio|Libra": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Aries|Scorpio|Scorpio": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Scorpio|Capricorn": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Scorpio|Aquarius": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Scorpio|Pisces": {
+    "revelName": "Smoldering Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Aries|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Aries|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Aries|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Aries|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Aries|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Aries|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Aries|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Aries|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Aries|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Aries|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Aries|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Aries|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Aries|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Aries|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Aries|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Aries|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Aries|Aquarius|Aries": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Aries|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Aries|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Aries|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Aries|Aquarius|Leo": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Aries|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Aries|Aquarius|Libra": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Aries|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Aries|Pisces|Aries": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and everyone in the room felt it",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Aries|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — with taste that borders on unfair",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Aries|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and somehow charmed every single one of them",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Aries|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and meant every single second of it",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Aries|Pisces|Leo": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and looked incredible doing it",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Aries|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and got it exactly right",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Aries|Pisces|Libra": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and left everyone wanting the sequel",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Aries|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and you still don't fully know them",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Aries|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and made it the best night of your life",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Aries|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and never once broke composure",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Aries|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and nobody else could have pulled that off",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Aries|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Firecut Who Never Waits for the Green Light — and you're still not sure it was real",
+    "flattery": "Raw, igniting, first-take genius, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "raw, igniting, first-take genius",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aries",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Aries|Aries": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Taurus|Aries|Taurus": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Aries|Gemini": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Aries|Cancer": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Aries|Leo": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Taurus|Aries|Virgo": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Aries|Libra": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Taurus|Aries|Scorpio": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Aries|Sagittarius": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Aries|Capricorn": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Aries|Aquarius": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Aries|Pisces": {
+    "revelName": "Combustible Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Taurus|Aries": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Taurus|Taurus|Taurus": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Taurus|Gemini": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Taurus|Cancer": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Taurus|Leo": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Taurus|Taurus|Virgo": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Taurus|Libra": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Taurus|Taurus|Scorpio": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Taurus|Capricorn": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Taurus|Aquarius": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Taurus|Pisces": {
+    "revelName": "Slow Burn Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Taurus|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Taurus|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Taurus|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Cancer|Aries": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Taurus|Cancer|Taurus": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Cancer|Gemini": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Cancer|Cancer": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Cancer|Leo": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Taurus|Cancer|Virgo": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Cancer|Libra": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Taurus|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Cancer|Pisces": {
+    "revelName": "Deeply Felt Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Leo|Aries": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Taurus|Leo|Taurus": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Leo|Gemini": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Leo|Cancer": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Leo|Leo": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Taurus|Leo|Virgo": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Leo|Libra": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Taurus|Leo|Scorpio": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Leo|Sagittarius": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Leo|Capricorn": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Leo|Aquarius": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Leo|Pisces": {
+    "revelName": "Golden Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Taurus|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Taurus|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Taurus|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Libra|Aries": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Taurus|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Libra|Leo": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Taurus|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Libra|Libra": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Taurus|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Scorpio|Aries": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Taurus|Scorpio|Taurus": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Scorpio|Gemini": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Scorpio|Cancer": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Scorpio|Leo": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Taurus|Scorpio|Virgo": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Scorpio|Libra": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Taurus|Scorpio|Scorpio": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Scorpio|Capricorn": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Scorpio|Aquarius": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Scorpio|Pisces": {
+    "revelName": "Smoldering Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Taurus|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Taurus|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Taurus|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Taurus|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Taurus|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Taurus|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Aquarius|Aries": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Taurus|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Aquarius|Leo": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Taurus|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Aquarius|Libra": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Taurus|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Taurus|Pisces|Aries": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and everyone in the room felt it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Taurus|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — with taste that borders on unfair",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Taurus|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and somehow charmed every single one of them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Taurus|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and meant every single second of it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Taurus|Pisces|Leo": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and looked incredible doing it",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Taurus|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and got it exactly right",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Taurus|Pisces|Libra": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and left everyone wanting the sequel",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Taurus|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and you still don't fully know them",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Taurus|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and made it the best night of your life",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Taurus|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and never once broke composure",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Taurus|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and nobody else could have pulled that off",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Taurus|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Velvet Lead Who Was Always Going to Win — and you're still not sure it was real",
+    "flattery": "Magnetic, unhurried, inevitably iconic, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "magnetic, unhurried, inevitably iconic",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Taurus",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Aries|Aries": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Gemini|Aries|Taurus": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Aries|Gemini": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Aries|Cancer": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Aries|Leo": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Gemini|Aries|Virgo": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Aries|Libra": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Gemini|Aries|Scorpio": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Aries|Sagittarius": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Aries|Capricorn": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Aries|Aquarius": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Aries|Pisces": {
+    "revelName": "Combustible Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Taurus|Aries": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Gemini|Taurus|Taurus": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Taurus|Gemini": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Taurus|Cancer": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Taurus|Leo": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Gemini|Taurus|Virgo": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Taurus|Libra": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Gemini|Taurus|Scorpio": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Taurus|Capricorn": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Taurus|Aquarius": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Taurus|Pisces": {
+    "revelName": "Slow Burn Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Gemini|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Gemini|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Gemini|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Cancer|Aries": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Gemini|Cancer|Taurus": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Cancer|Gemini": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Cancer|Cancer": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Cancer|Leo": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Gemini|Cancer|Virgo": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Cancer|Libra": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Gemini|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Cancer|Pisces": {
+    "revelName": "Deeply Felt Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Leo|Aries": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Gemini|Leo|Taurus": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Leo|Gemini": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Leo|Cancer": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Leo|Leo": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Gemini|Leo|Virgo": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Leo|Libra": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Gemini|Leo|Scorpio": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Leo|Sagittarius": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Leo|Capricorn": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Leo|Aquarius": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Leo|Pisces": {
+    "revelName": "Golden Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Gemini|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Gemini|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Gemini|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Libra|Aries": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Gemini|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Libra|Leo": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Gemini|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Libra|Libra": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Gemini|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Scorpio|Aries": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Gemini|Scorpio|Taurus": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Scorpio|Gemini": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Scorpio|Cancer": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Scorpio|Leo": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Gemini|Scorpio|Virgo": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Scorpio|Libra": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Gemini|Scorpio|Scorpio": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Scorpio|Capricorn": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Scorpio|Aquarius": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Scorpio|Pisces": {
+    "revelName": "Smoldering Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Gemini|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Gemini|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Gemini|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Gemini|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Gemini|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Gemini|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Aquarius|Aries": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Gemini|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Aquarius|Leo": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Gemini|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Aquarius|Libra": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Gemini|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Gemini|Pisces|Aries": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and everyone in the room felt it",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Gemini|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — with taste that borders on unfair",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Gemini|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and somehow charmed every single one of them",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Gemini|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and meant every single second of it",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Gemini|Pisces|Leo": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and looked incredible doing it",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Gemini|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and got it exactly right",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Gemini|Pisces|Libra": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and left everyone wanting the sequel",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Gemini|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and you still don't fully know them",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Gemini|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and made it the best night of your life",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Gemini|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and never once broke composure",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Gemini|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and nobody else could have pulled that off",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Gemini|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Double-Billed Darling Nobody Can Pin Down — and you're still not sure it was real",
+    "flattery": "Electric, mercurial, twice as interesting, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "electric, mercurial, twice as interesting",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Gemini",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Aries|Aries": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Cancer|Aries|Taurus": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Aries|Gemini": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Aries|Cancer": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Aries|Leo": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Cancer|Aries|Virgo": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Aries|Libra": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Cancer|Aries|Scorpio": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Aries|Sagittarius": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Aries|Capricorn": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Aries|Aquarius": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Aries|Pisces": {
+    "revelName": "Combustible Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Taurus|Aries": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Cancer|Taurus|Taurus": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Taurus|Gemini": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Taurus|Cancer": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Taurus|Leo": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Cancer|Taurus|Virgo": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Taurus|Libra": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Cancer|Taurus|Scorpio": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Taurus|Capricorn": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Taurus|Aquarius": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Taurus|Pisces": {
+    "revelName": "Slow Burn Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Cancer|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Cancer|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Cancer|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Cancer|Aries": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Cancer|Cancer|Taurus": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Cancer|Gemini": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Cancer|Cancer": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Cancer|Leo": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Cancer|Cancer|Virgo": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Cancer|Libra": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Cancer|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Cancer|Pisces": {
+    "revelName": "Deeply Felt Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Leo|Aries": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Cancer|Leo|Taurus": {
+    "revelName": "Golden Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Leo|Gemini": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Leo|Cancer": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Leo|Leo": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Cancer|Leo|Virgo": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Leo|Libra": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Cancer|Leo|Scorpio": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Leo|Sagittarius": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Leo|Capricorn": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Leo|Aquarius": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Leo|Pisces": {
+    "revelName": "Golden Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Cancer|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Cancer|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Cancer|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Libra|Aries": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Cancer|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Libra|Leo": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Cancer|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Libra|Libra": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Cancer|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Scorpio|Aries": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Cancer|Scorpio|Taurus": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Scorpio|Gemini": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Scorpio|Cancer": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Scorpio|Leo": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Cancer|Scorpio|Virgo": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Scorpio|Libra": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Cancer|Scorpio|Scorpio": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Scorpio|Capricorn": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Scorpio|Aquarius": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Scorpio|Pisces": {
+    "revelName": "Smoldering Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Cancer|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Cancer|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Cancer|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Cancer|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Cancer|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Cancer|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Aquarius|Aries": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Cancer|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Aquarius|Leo": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Cancer|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Aquarius|Libra": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Cancer|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Cancer|Pisces|Aries": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and everyone in the room felt it",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Cancer|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — with taste that borders on unfair",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Cancer|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and somehow charmed every single one of them",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Cancer|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and meant every single second of it",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Cancer|Pisces|Leo": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and looked incredible doing it",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Cancer|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and got it exactly right",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Cancer|Pisces|Libra": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and left everyone wanting the sequel",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Cancer|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and you still don't fully know them",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Cancer|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and made it the best night of your life",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Cancer|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and never once broke composure",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Cancer|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and nobody else could have pulled that off",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Cancer|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Method Actor With a Perfect Memory — and you're still not sure it was real",
+    "flattery": "Feeling everything, forgetting nothing, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "feeling everything, forgetting nothing",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Cancer",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Leo|Aries|Aries": {
+    "revelName": "Combustible Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Leo|Aries|Taurus": {
+    "revelName": "Combustible Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Leo|Aries|Gemini": {
+    "revelName": "Combustible Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Leo|Aries|Cancer": {
+    "revelName": "Combustible Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Leo|Aries|Leo": {
+    "revelName": "Combustible Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Leo|Aries|Virgo": {
+    "revelName": "Combustible Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Leo|Aries|Libra": {
+    "revelName": "Combustible Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Leo|Aries|Scorpio": {
+    "revelName": "Combustible Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Aries|Sagittarius": {
+    "revelName": "Combustible Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Aries|Capricorn": {
+    "revelName": "Combustible Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Aries|Aquarius": {
+    "revelName": "Combustible Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Aries|Pisces": {
+    "revelName": "Combustible Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Leo|Taurus|Aries": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Leo|Taurus|Taurus": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Leo|Taurus|Gemini": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Leo|Taurus|Cancer": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Leo|Taurus|Leo": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Leo|Taurus|Virgo": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Leo|Taurus|Libra": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Leo|Taurus|Scorpio": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Taurus|Capricorn": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Taurus|Aquarius": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Taurus|Pisces": {
+    "revelName": "Slow Burn Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Leo|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Leo|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Leo|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Leo|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Leo|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Leo|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Leo|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Leo|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Leo|Cancer|Aries": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Leo|Cancer|Taurus": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Leo|Cancer|Gemini": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Leo|Cancer|Cancer": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Leo|Cancer|Leo": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Leo|Cancer|Virgo": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Leo|Cancer|Libra": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Leo|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Cancer|Pisces": {
+    "revelName": "Deeply Felt Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Leo|Leo|Aries": {
+    "revelName": "Golden Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Leo|Leo|Taurus": {
+    "revelName": "Golden Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Leo|Leo|Gemini": {
+    "revelName": "Golden Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Leo|Leo|Cancer": {
+    "revelName": "Golden Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Leo|Leo|Leo": {
+    "revelName": "Golden Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Leo|Leo|Virgo": {
+    "revelName": "Golden Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Leo|Leo|Libra": {
+    "revelName": "Golden Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Leo|Leo|Scorpio": {
+    "revelName": "Golden Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Leo|Sagittarius": {
+    "revelName": "Golden Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Leo|Capricorn": {
+    "revelName": "Golden Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Leo|Aquarius": {
+    "revelName": "Golden Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Leo|Pisces": {
+    "revelName": "Golden Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Leo|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Leo|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Leo|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Leo|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Leo|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Leo|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Leo|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Leo|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Leo|Libra|Aries": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Leo|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Leo|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Leo|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Leo|Libra|Leo": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Leo|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Leo|Libra|Libra": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Leo|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Leo|Scorpio|Aries": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Leo|Scorpio|Taurus": {
+    "revelName": "Smoldering Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Leo|Scorpio|Gemini": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Leo|Scorpio|Cancer": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Leo|Scorpio|Leo": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Leo|Scorpio|Virgo": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Leo|Scorpio|Libra": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Leo|Scorpio|Scorpio": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Scorpio|Capricorn": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Scorpio|Aquarius": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Scorpio|Pisces": {
+    "revelName": "Smoldering Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Leo|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Leo|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Leo|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Leo|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Leo|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Leo|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Leo|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Leo|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Leo|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Leo|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Leo|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Leo|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Leo|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Leo|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Leo|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Leo|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Leo|Aquarius|Aries": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Leo|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Leo|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Leo|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Leo|Aquarius|Leo": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Leo|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Leo|Aquarius|Libra": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Leo|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Leo|Pisces|Aries": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and everyone in the room felt it",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Leo|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — with taste that borders on unfair",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Leo|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and somehow charmed every single one of them",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Leo|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and meant every single second of it",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Leo|Pisces|Leo": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and looked incredible doing it",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Leo|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and got it exactly right",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Leo|Pisces|Libra": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and left everyone wanting the sequel",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Leo|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and you still don't fully know them",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Leo|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and made it the best night of your life",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Leo|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and never once broke composure",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Leo|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and nobody else could have pulled that off",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Leo|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Main Event They Built the Venue For — and you're still not sure it was real",
+    "flattery": "Luminous, undeniable, born for the frame, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "luminous, undeniable, born for the frame",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Leo",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Aries|Aries": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Virgo|Aries|Taurus": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Aries|Gemini": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Aries|Cancer": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Aries|Leo": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Virgo|Aries|Virgo": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Aries|Libra": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Virgo|Aries|Scorpio": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Aries|Sagittarius": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Aries|Capricorn": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Aries|Aquarius": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Aries|Pisces": {
+    "revelName": "Combustible Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Taurus|Aries": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Virgo|Taurus|Taurus": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Taurus|Gemini": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Taurus|Cancer": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Taurus|Leo": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Virgo|Taurus|Virgo": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Taurus|Libra": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Virgo|Taurus|Scorpio": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Taurus|Capricorn": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Taurus|Aquarius": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Taurus|Pisces": {
+    "revelName": "Slow Burn Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Virgo|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Virgo|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Virgo|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Cancer|Aries": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Virgo|Cancer|Taurus": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Cancer|Gemini": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Cancer|Cancer": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Cancer|Leo": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Virgo|Cancer|Virgo": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Cancer|Libra": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Virgo|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Cancer|Pisces": {
+    "revelName": "Deeply Felt Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Leo|Aries": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Virgo|Leo|Taurus": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Leo|Gemini": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Leo|Cancer": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Leo|Leo": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Virgo|Leo|Virgo": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Leo|Libra": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Virgo|Leo|Scorpio": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Leo|Sagittarius": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Leo|Capricorn": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Leo|Aquarius": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Leo|Pisces": {
+    "revelName": "Golden Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Virgo|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Virgo|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Virgo|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Libra|Aries": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Virgo|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Libra|Leo": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Virgo|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Libra|Libra": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Virgo|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Scorpio|Aries": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Virgo|Scorpio|Taurus": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Scorpio|Gemini": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Scorpio|Cancer": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Scorpio|Leo": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Virgo|Scorpio|Virgo": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Scorpio|Libra": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Virgo|Scorpio|Scorpio": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Scorpio|Capricorn": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Scorpio|Aquarius": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Scorpio|Pisces": {
+    "revelName": "Smoldering Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Virgo|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Virgo|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Virgo|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Virgo|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Virgo|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Virgo|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Aquarius|Aries": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Virgo|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Aquarius|Leo": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Virgo|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Aquarius|Libra": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Virgo|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Virgo|Pisces|Aries": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and everyone in the room felt it",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Virgo|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — with taste that borders on unfair",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Virgo|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and somehow charmed every single one of them",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Virgo|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and meant every single second of it",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Virgo|Pisces|Leo": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and looked incredible doing it",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Virgo|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and got it exactly right",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Virgo|Pisces|Libra": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and left everyone wanting the sequel",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Virgo|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and you still don't fully know them",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Virgo|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and made it the best night of your life",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Virgo|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and never once broke composure",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Virgo|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and nobody else could have pulled that off",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Virgo|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Auteur Who Wrote the Script and Rewrote It — and you're still not sure it was real",
+    "flattery": "Precise, devastating, quietly untouchable, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "precise, devastating, quietly untouchable",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Virgo",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Libra|Aries|Aries": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Libra|Aries|Taurus": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Libra|Aries|Gemini": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Libra|Aries|Cancer": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Libra|Aries|Leo": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Libra|Aries|Virgo": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Libra|Aries|Libra": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Libra|Aries|Scorpio": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Aries|Sagittarius": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Aries|Capricorn": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Aries|Aquarius": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Aries|Pisces": {
+    "revelName": "Combustible Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Libra|Taurus|Aries": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Libra|Taurus|Taurus": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Libra|Taurus|Gemini": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Libra|Taurus|Cancer": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Libra|Taurus|Leo": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Libra|Taurus|Virgo": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Libra|Taurus|Libra": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Libra|Taurus|Scorpio": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Taurus|Capricorn": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Taurus|Aquarius": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Taurus|Pisces": {
+    "revelName": "Slow Burn Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Libra|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Libra|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Libra|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Libra|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Libra|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Libra|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Libra|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Libra|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Libra|Cancer|Aries": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Libra|Cancer|Taurus": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Libra|Cancer|Gemini": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Libra|Cancer|Cancer": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Libra|Cancer|Leo": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Libra|Cancer|Virgo": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Libra|Cancer|Libra": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Libra|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Cancer|Pisces": {
+    "revelName": "Deeply Felt Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Libra|Leo|Aries": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Libra|Leo|Taurus": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Libra|Leo|Gemini": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Libra|Leo|Cancer": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Libra|Leo|Leo": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Libra|Leo|Virgo": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Libra|Leo|Libra": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Libra|Leo|Scorpio": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Leo|Sagittarius": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Leo|Capricorn": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Leo|Aquarius": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Leo|Pisces": {
+    "revelName": "Golden Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Libra|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Libra|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Libra|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Libra|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Libra|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Libra|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Libra|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Libra|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Libra|Libra|Aries": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Libra|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Libra|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Libra|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Libra|Libra|Leo": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Libra|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Libra|Libra|Libra": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Libra|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Libra|Scorpio|Aries": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Libra|Scorpio|Taurus": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Libra|Scorpio|Gemini": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Libra|Scorpio|Cancer": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Libra|Scorpio|Leo": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Libra|Scorpio|Virgo": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Libra|Scorpio|Libra": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Libra|Scorpio|Scorpio": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Scorpio|Capricorn": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Scorpio|Aquarius": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Scorpio|Pisces": {
+    "revelName": "Smoldering Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Libra|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Libra|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Libra|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Libra|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Libra|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Libra|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Libra|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Libra|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Libra|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Libra|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Libra|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Libra|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Libra|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Libra|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Libra|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Libra|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Libra|Aquarius|Aries": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Libra|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Libra|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Libra|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Libra|Aquarius|Leo": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Libra|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Libra|Aquarius|Libra": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Libra|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Libra|Pisces|Aries": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and everyone in the room felt it",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Libra|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — with taste that borders on unfair",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Libra|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and somehow charmed every single one of them",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Libra|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and meant every single second of it",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Libra|Pisces|Leo": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and looked incredible doing it",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Libra|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and got it exactly right",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Libra|Pisces|Libra": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and left everyone wanting the sequel",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Libra|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and you still don't fully know them",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Libra|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and made it the best night of your life",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Libra|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and never once broke composure",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Libra|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and nobody else could have pulled that off",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Libra|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Co-Star Who Somehow Steals the Film — and you're still not sure it was real",
+    "flattery": "Effortless, radiant, impossible to look away from, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "effortless, radiant, impossible to look away from",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Libra",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Aries|Aries": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Aries|Taurus": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Aries|Gemini": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Aries|Cancer": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Aries|Leo": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Aries|Virgo": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Aries|Libra": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Aries|Scorpio": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Aries|Sagittarius": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Aries|Capricorn": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Aries|Aquarius": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Aries|Pisces": {
+    "revelName": "Combustible Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Taurus|Aries": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Taurus|Taurus": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Taurus|Gemini": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Taurus|Cancer": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Taurus|Leo": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Taurus|Virgo": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Taurus|Libra": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Taurus|Scorpio": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Taurus|Capricorn": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Taurus|Aquarius": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Taurus|Pisces": {
+    "revelName": "Slow Burn Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Cancer|Aries": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Cancer|Taurus": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Cancer|Gemini": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Cancer|Cancer": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Cancer|Leo": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Cancer|Virgo": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Cancer|Libra": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Cancer|Pisces": {
+    "revelName": "Deeply Felt Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Leo|Aries": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Leo|Taurus": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Leo|Gemini": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Leo|Cancer": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Leo|Leo": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Leo|Virgo": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Leo|Libra": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Leo|Scorpio": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Leo|Sagittarius": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Leo|Capricorn": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Leo|Aquarius": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Leo|Pisces": {
+    "revelName": "Golden Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Libra|Aries": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Libra|Leo": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Libra|Libra": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Scorpio|Aries": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Scorpio|Taurus": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Scorpio|Gemini": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Scorpio|Cancer": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Scorpio|Leo": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Scorpio|Virgo": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Scorpio|Libra": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Scorpio|Scorpio": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Scorpio|Capricorn": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Scorpio|Aquarius": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Scorpio|Pisces": {
+    "revelName": "Smoldering Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Aquarius|Aries": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Aquarius|Leo": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Aquarius|Libra": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Scorpio|Pisces|Aries": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and everyone in the room felt it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Scorpio|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — with taste that borders on unfair",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Scorpio|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and somehow charmed every single one of them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Scorpio|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and meant every single second of it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Scorpio|Pisces|Leo": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and looked incredible doing it",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Scorpio|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and got it exactly right",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Scorpio|Pisces|Libra": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and left everyone wanting the sequel",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Scorpio|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and you still don't fully know them",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Scorpio|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and made it the best night of your life",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Scorpio|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and never once broke composure",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Scorpio|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and nobody else could have pulled that off",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Scorpio|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Dark Horse the Critics Couldn't Ignore — and you're still not sure it was real",
+    "flattery": "Smoldering, knowing, dangerously compelling, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "smoldering, knowing, dangerously compelling",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Scorpio",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Aries|Aries": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Aries|Taurus": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Aries|Gemini": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Aries|Cancer": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Aries|Leo": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Aries|Virgo": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Aries|Libra": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Aries|Scorpio": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Aries|Sagittarius": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Aries|Capricorn": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Aries|Aquarius": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Aries|Pisces": {
+    "revelName": "Combustible Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Taurus|Aries": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Taurus|Taurus": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Taurus|Gemini": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Taurus|Cancer": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Taurus|Leo": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Taurus|Virgo": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Taurus|Libra": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Taurus|Scorpio": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Taurus|Capricorn": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Taurus|Aquarius": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Taurus|Pisces": {
+    "revelName": "Slow Burn Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Cancer|Aries": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Cancer|Taurus": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Cancer|Gemini": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Cancer|Cancer": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Cancer|Leo": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Cancer|Virgo": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Cancer|Libra": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Cancer|Pisces": {
+    "revelName": "Deeply Felt Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Leo|Aries": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Leo|Taurus": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Leo|Gemini": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Leo|Cancer": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Leo|Leo": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Leo|Virgo": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Leo|Libra": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Leo|Scorpio": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Leo|Sagittarius": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Leo|Capricorn": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Leo|Aquarius": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Leo|Pisces": {
+    "revelName": "Golden Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Libra|Aries": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Libra|Leo": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Libra|Libra": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Scorpio|Aries": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Scorpio|Taurus": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Scorpio|Gemini": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Scorpio|Cancer": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Scorpio|Leo": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Scorpio|Virgo": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Scorpio|Libra": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Scorpio|Scorpio": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Scorpio|Capricorn": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Scorpio|Aquarius": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Scorpio|Pisces": {
+    "revelName": "Smoldering Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Aquarius|Aries": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Aquarius|Leo": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Aquarius|Libra": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Sagittarius|Pisces|Aries": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and everyone in the room felt it",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Sagittarius|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — with taste that borders on unfair",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Sagittarius|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and somehow charmed every single one of them",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Sagittarius|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and meant every single second of it",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Sagittarius|Pisces|Leo": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and looked incredible doing it",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Sagittarius|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and got it exactly right",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Sagittarius|Pisces|Libra": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and left everyone wanting the sequel",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Sagittarius|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and you still don't fully know them",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Sagittarius|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and made it the best night of your life",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Sagittarius|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and never once broke composure",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Sagittarius|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and nobody else could have pulled that off",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Sagittarius|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Road Cut Shot in One Glorious Take — and you're still not sure it was real",
+    "flattery": "Uncontainable, alive, always somewhere better, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "uncontainable, alive, always somewhere better",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Sagittarius",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Aries|Aries": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Aries|Taurus": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Aries|Gemini": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Aries|Cancer": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Aries|Leo": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Aries|Virgo": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Aries|Libra": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Aries|Scorpio": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Aries|Sagittarius": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Aries|Capricorn": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Aries|Aquarius": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Aries|Pisces": {
+    "revelName": "Combustible Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Taurus|Aries": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Taurus|Taurus": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Taurus|Gemini": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Taurus|Cancer": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Taurus|Leo": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Taurus|Virgo": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Taurus|Libra": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Taurus|Scorpio": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Taurus|Capricorn": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Taurus|Aquarius": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Taurus|Pisces": {
+    "revelName": "Slow Burn Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Cancer|Aries": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Cancer|Taurus": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Cancer|Gemini": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Cancer|Cancer": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Cancer|Leo": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Cancer|Virgo": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Cancer|Libra": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Cancer|Pisces": {
+    "revelName": "Deeply Felt Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Leo|Aries": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Leo|Taurus": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Leo|Gemini": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Leo|Cancer": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Leo|Leo": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Leo|Virgo": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Leo|Libra": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Leo|Scorpio": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Leo|Sagittarius": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Leo|Capricorn": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Leo|Aquarius": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Leo|Pisces": {
+    "revelName": "Golden Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Libra|Aries": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Libra|Leo": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Libra|Libra": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Scorpio|Aries": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Scorpio|Taurus": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Scorpio|Gemini": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Scorpio|Cancer": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Scorpio|Leo": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Scorpio|Virgo": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Scorpio|Libra": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Scorpio|Scorpio": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Scorpio|Capricorn": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Scorpio|Aquarius": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Scorpio|Pisces": {
+    "revelName": "Smoldering Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Aquarius|Aries": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Aquarius|Leo": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Aquarius|Libra": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Capricorn|Pisces|Aries": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and everyone in the room felt it",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Capricorn|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — with taste that borders on unfair",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Capricorn|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and somehow charmed every single one of them",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Capricorn|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and meant every single second of it",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Capricorn|Pisces|Leo": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and looked incredible doing it",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Capricorn|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and got it exactly right",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Capricorn|Pisces|Libra": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and left everyone wanting the sequel",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Capricorn|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and you still don't fully know them",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Capricorn|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and made it the best night of your life",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Capricorn|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and never once broke composure",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Capricorn|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and nobody else could have pulled that off",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Capricorn|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Studio Head Who Also Took Home the Trophy — and you're still not sure it was real",
+    "flattery": "Composed, exacting, always ten steps ahead, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "composed, exacting, always ten steps ahead",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Capricorn",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Aries|Aries": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Aries|Taurus": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Aries|Gemini": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Aries|Cancer": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Aries|Leo": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Aries|Virgo": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Aries|Libra": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Aries|Scorpio": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Aries|Sagittarius": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Aries|Capricorn": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Aries|Aquarius": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Aries|Pisces": {
+    "revelName": "Combustible Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Taurus|Aries": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Taurus|Taurus": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Taurus|Gemini": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Taurus|Cancer": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Taurus|Leo": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Taurus|Virgo": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Taurus|Libra": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Taurus|Scorpio": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Taurus|Capricorn": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Taurus|Aquarius": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Taurus|Pisces": {
+    "revelName": "Slow Burn Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Cancer|Aries": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Cancer|Taurus": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Cancer|Gemini": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Cancer|Cancer": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Cancer|Leo": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Cancer|Virgo": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Cancer|Libra": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Cancer|Pisces": {
+    "revelName": "Deeply Felt Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Leo|Aries": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Leo|Taurus": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Leo|Gemini": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Leo|Cancer": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Leo|Leo": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Leo|Virgo": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Leo|Libra": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Leo|Scorpio": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Leo|Sagittarius": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Leo|Capricorn": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Leo|Aquarius": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Leo|Pisces": {
+    "revelName": "Golden Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Libra|Aries": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Libra|Leo": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Libra|Libra": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Scorpio|Aries": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Scorpio|Taurus": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Scorpio|Gemini": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Scorpio|Cancer": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Scorpio|Leo": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Scorpio|Virgo": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Scorpio|Libra": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Scorpio|Scorpio": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Scorpio|Capricorn": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Scorpio|Aquarius": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Scorpio|Pisces": {
+    "revelName": "Smoldering Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Aquarius|Aries": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Aquarius|Leo": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Aquarius|Libra": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Aquarius|Pisces|Aries": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and everyone in the room felt it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Aquarius|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — with taste that borders on unfair",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Aquarius|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and somehow charmed every single one of them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Aquarius|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and meant every single second of it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Aquarius|Pisces|Leo": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and looked incredible doing it",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Aquarius|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and got it exactly right",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Aquarius|Pisces|Libra": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and left everyone wanting the sequel",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Aquarius|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and you still don't fully know them",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Aquarius|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and made it the best night of your life",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Aquarius|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and never once broke composure",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Aquarius|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and nobody else could have pulled that off",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Aquarius|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Cult Classic Nobody Understood Until Now — and you're still not sure it was real",
+    "flattery": "Singular, ahead of the curve, legendarily strange, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "singular, ahead of the curve, legendarily strange",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Aquarius",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Aries|Aries": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Aries"
+  },
+  "Pisces|Aries|Taurus": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Aries|Gemini": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Aries|Cancer": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Aries|Leo": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Leo"
+  },
+  "Pisces|Aries|Virgo": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Aries|Libra": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Libra"
+  },
+  "Pisces|Aries|Scorpio": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Aries|Sagittarius": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Aries|Capricorn": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Aries|Aquarius": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Aries|Pisces": {
+    "revelName": "Combustible Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes decisions before the scene is set. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Combustible",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Aries",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Taurus|Aries": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Aries"
+  },
+  "Pisces|Taurus|Taurus": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Taurus|Gemini": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Taurus|Cancer": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Taurus|Leo": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Leo"
+  },
+  "Pisces|Taurus|Virgo": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Taurus|Libra": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Libra"
+  },
+  "Pisces|Taurus|Scorpio": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Taurus|Sagittarius": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Taurus|Capricorn": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Taurus|Aquarius": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Taurus|Pisces": {
+    "revelName": "Slow Burn Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was always going to outlast everyone. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Slow Burn",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Taurus",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Gemini|Aries": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Aries"
+  },
+  "Pisces|Gemini|Taurus": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Gemini|Gemini": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Gemini|Cancer": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Gemini|Leo": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Leo"
+  },
+  "Pisces|Gemini|Virgo": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Gemini|Libra": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Libra"
+  },
+  "Pisces|Gemini|Scorpio": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Gemini|Sagittarius": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Gemini|Capricorn": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Gemini|Aquarius": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Gemini|Pisces": {
+    "revelName": "Gloriously Inconsistent Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who delivers a different performance every take. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Gloriously Inconsistent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Gemini",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Cancer|Aries": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Aries"
+  },
+  "Pisces|Cancer|Taurus": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Cancer|Gemini": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Cancer|Cancer": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Cancer|Leo": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Leo"
+  },
+  "Pisces|Cancer|Virgo": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Cancer|Libra": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Libra"
+  },
+  "Pisces|Cancer|Scorpio": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Cancer|Sagittarius": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Cancer|Capricorn": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Cancer|Aquarius": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Cancer|Pisces": {
+    "revelName": "Deeply Felt Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who makes the whole room feel it without trying. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Deeply Felt",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Cancer",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Leo|Aries": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Aries"
+  },
+  "Pisces|Leo|Taurus": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Leo|Gemini": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Leo|Cancer": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Leo|Leo": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Leo"
+  },
+  "Pisces|Leo|Virgo": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Leo|Libra": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Libra"
+  },
+  "Pisces|Leo|Scorpio": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Leo|Sagittarius": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Leo|Capricorn": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Leo|Aquarius": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Leo|Pisces": {
+    "revelName": "Golden Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who the camera finds even when it shouldn't. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Golden",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Leo",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Virgo|Aries": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Aries"
+  },
+  "Pisces|Virgo|Taurus": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Virgo|Gemini": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Virgo|Cancer": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Virgo|Leo": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Leo"
+  },
+  "Pisces|Virgo|Virgo": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Virgo|Libra": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Libra"
+  },
+  "Pisces|Virgo|Scorpio": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Virgo|Sagittarius": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Virgo|Capricorn": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Virgo|Aquarius": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Virgo|Pisces": {
+    "revelName": "Exquisitely Calibrated Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who noticed everything you thought you hid. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Exquisitely Calibrated",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Virgo",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Libra|Aries": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Aries"
+  },
+  "Pisces|Libra|Taurus": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Libra|Gemini": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Libra|Cancer": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Libra|Leo": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Leo"
+  },
+  "Pisces|Libra|Virgo": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Libra|Libra": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Libra"
+  },
+  "Pisces|Libra|Scorpio": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Libra|Sagittarius": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Libra|Capricorn": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Libra|Aquarius": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Libra|Pisces": {
+    "revelName": "Quietly Magnetic Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who everyone agrees on, somehow. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Quietly Magnetic",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Libra",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Scorpio|Aries": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Aries"
+  },
+  "Pisces|Scorpio|Taurus": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Scorpio|Gemini": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Scorpio|Cancer": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Scorpio|Leo": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Leo"
+  },
+  "Pisces|Scorpio|Virgo": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Scorpio|Libra": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Libra"
+  },
+  "Pisces|Scorpio|Scorpio": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Scorpio|Sagittarius": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Scorpio|Capricorn": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Scorpio|Aquarius": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Scorpio|Pisces": {
+    "revelName": "Smoldering Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who already knew how it ended. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Smoldering",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Scorpio",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Sagittarius|Aries": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aries"
+  },
+  "Pisces|Sagittarius|Taurus": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Sagittarius|Gemini": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Sagittarius|Cancer": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Sagittarius|Leo": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Leo"
+  },
+  "Pisces|Sagittarius|Virgo": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Sagittarius|Libra": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Libra"
+  },
+  "Pisces|Sagittarius|Scorpio": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Sagittarius|Sagittarius": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Sagittarius|Capricorn": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Sagittarius|Aquarius": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Sagittarius|Pisces": {
+    "revelName": "Wildly Alive Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who turned the detour into the destination. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Wildly Alive",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Sagittarius",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Capricorn|Aries": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Aries"
+  },
+  "Pisces|Capricorn|Taurus": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Capricorn|Gemini": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Capricorn|Cancer": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Capricorn|Leo": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Leo"
+  },
+  "Pisces|Capricorn|Virgo": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Capricorn|Libra": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Libra"
+  },
+  "Pisces|Capricorn|Scorpio": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Capricorn|Sagittarius": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Capricorn|Capricorn": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Capricorn|Aquarius": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Capricorn|Pisces": {
+    "revelName": "Dangerously Competent Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who made it look effortless and wasn't. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Dangerously Competent",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Capricorn",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Aquarius|Aries": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Aries"
+  },
+  "Pisces|Aquarius|Taurus": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Aquarius|Gemini": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Aquarius|Cancer": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Aquarius|Leo": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Leo"
+  },
+  "Pisces|Aquarius|Virgo": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Aquarius|Libra": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Libra"
+  },
+  "Pisces|Aquarius|Scorpio": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Aquarius|Sagittarius": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Aquarius|Capricorn": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Aquarius|Aquarius": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Aquarius|Pisces": {
+    "revelName": "Defiantly Original Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who was doing this before it had a name. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Defiantly Original",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Aquarius",
+    "venusSign": "Pisces"
+  },
+  "Pisces|Pisces|Aries": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and everyone in the room felt it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person you follow without asking where.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you follow without asking where",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Aries"
+  },
+  "Pisces|Pisces|Taurus": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — with taste that borders on unfair",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person rooms rearrange themselves around.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person rooms rearrange themselves around",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Taurus"
+  },
+  "Pisces|Pisces|Gemini": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and somehow charmed every single one of them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person who makes everyone feel chosen.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes everyone feel chosen",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Gemini"
+  },
+  "Pisces|Pisces|Cancer": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and meant every single second of it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person who makes love feel like cinema.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes love feel like cinema",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Cancer"
+  },
+  "Pisces|Pisces|Leo": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and looked incredible doing it",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person who makes other people more interesting.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes other people more interesting",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Leo"
+  },
+  "Pisces|Pisces|Virgo": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and got it exactly right",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person whose attention feels like a gift.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose attention feels like a gift",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Virgo"
+  },
+  "Pisces|Pisces|Libra": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and left everyone wanting the sequel",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person who makes falling easy and leaving hard.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes falling easy and leaving hard",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Libra"
+  },
+  "Pisces|Pisces|Scorpio": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and you still don't fully know them",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person you write songs about after.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you write songs about after",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Scorpio"
+  },
+  "Pisces|Pisces|Sagittarius": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and made it the best night of your life",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person who makes ordinary things feel like an event.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes ordinary things feel like an event",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Sagittarius"
+  },
+  "Pisces|Pisces|Capricorn": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and never once broke composure",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person whose approval actually means something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person whose approval actually means something",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Capricorn"
+  },
+  "Pisces|Pisces|Aquarius": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and nobody else could have pulled that off",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person you reference in conversation for years.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person you reference in conversation for years",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Aquarius"
+  },
+  "Pisces|Pisces|Pisces": {
+    "revelName": "Ethereally Intense Dream Sequence That Became the Whole Film — and you're still not sure it was real",
+    "flattery": "Otherworldly, haunting, the part you can't forget, who blurred the line between real and cinematic. the kind of person who makes you believe in something.",
+    "sunCore": "otherworldly, haunting, the part you can't forget",
+    "moonPrefix": "Ethereally Intense",
+    "venusPull": "the kind of person who makes you believe in something",
+    "sunSign": "Pisces",
+    "moonSign": "Pisces",
+    "venusSign": "Pisces"
+  }
+}


### PR DESCRIPTION
Cherry-pick placed it under astro-backend-clean-main/data/ but server.js loads from __dirname/data/ (repo root). Moved to correct path.